### PR TITLE
fix for double dashes in the prefixed gradient function

### DIFF
--- a/mixins.scss
+++ b/mixins.scss
@@ -124,7 +124,7 @@
 		$angle: nth($angles, 2);
 	}
 
-	$prefixed: '-' + $prefix + 'linear-gradient(' + $angle;
+	$prefixed: $prefix + 'linear-gradient(' + $angle;
 
 	@for $i from 1 through length($gradient) {
 		@if ($i > 2) {

--- a/partials/_multiple-backgrounds.scss
+++ b/partials/_multiple-backgrounds.scss
@@ -21,7 +21,7 @@
 		$angle: nth($angles, 2);
 	}
 
-	$prefixed: '-' + $prefix + 'linear-gradient(' + $angle;
+	$prefixed: $prefix + 'linear-gradient(' + $angle;
 
 	@for $i from 1 through length($gradient) {
 		@if ($i > 2) {


### PR DESCRIPTION
I've noticed that the function generates prefixed gradients with two dashes like --webkit-linear-gradient or ---o-linear-gradient
