### PR TITLE
Allow non-number values in rem mixin, basically treating them like 0 or auto

### DIFF
--- a/partials/_rem.scss
+++ b/partials/_rem.scss
@@ -10,7 +10,7 @@
 	@each $value in $values {
 
 		// If the value is zero, return 0
-		@if $value == 0 or $value == auto or type_of($value) != number {
+		@if $value == 0 or type_of($value) != number {
 			$px-values: append($px-values, $value);
 			$rem-values: append($rem-values, $value);
 


### PR DESCRIPTION
This makes it easier to use the mixin for things like border:

@include x-rem(border, .5 solid #f00);
