### PR TITLE
Remove extra -ms prefixed gradients

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,9 @@ submit Pull Requests when ever possible.
 
 * Add docs in mixins
 
+### 0.3.1 - 16.08.2013
+* Remove extra -ms prefixed gradients
+
 ### 0.3.0 - 19.05.2013
 * Add mixin for responsive breakpoints
 * Add mixin for animations

--- a/mixins.scss
+++ b/mixins.scss
@@ -239,7 +239,6 @@
  *   background-image: -webkit-gradient(linear, <direction - old converted>, from(<from>), to(<to>));
  *   background-image: -webkit-linear-gradient(<direction - converted>, <from>, <to>);
  *   background-image:    -moz-linear-gradient(<direction - converted>, <from>, <to>);
- *   background-image:     -ms-linear-gradient(<direction - converted>, <from>, <to>);
  *   background-image:      -o-linear-gradient(<direction - converted>, <from>, <to>);
  *   background-image:         linear-gradient(<direction>, <from>, <to>);
  *
@@ -262,7 +261,6 @@
 	background-image: -webkit-gradient(linear, unquote(nth($directions, 2)), from($from), to($to)); // Android 2.1-3.0
 	background-image: -webkit-linear-gradient(unquote(nth($directions, 1)), $from, $to);
 	background-image:    -moz-linear-gradient(unquote(nth($directions, 1)), $from, $to);
-	background-image:     -ms-linear-gradient(unquote(nth($directions, 1)), $from, $to);
 	background-image:      -o-linear-gradient(unquote(nth($directions, 1)), $from, $to);
 	background-image:         linear-gradient(unquote($direction),     $from, $to);
 }
@@ -408,7 +406,6 @@
  * @returns
  *   background-image: -webkit-linear-gradient(top, <stops[1]>, <stops[2]>, ..., <stops[n]>);
  *   background-image:    -moz-linear-gradient(top, <stops[1]>, <stops[2]>, ..., <stops[n]>);
- *   background-image:     -ms-linear-gradient(top, <stops[1]>, <stops[2]>, ..., <stops[n]>);
  *   background-image:      -o-linear-gradient(top, <stops[1]>, <stops[2]>, ..., <stops[n]>);
  *   background-image:         linear-gradient(to bottom, <stops[1]>, <stops[2]>, ..., <stops[n]>);
  *
@@ -464,7 +461,6 @@
 
 	background-image:  -webkit-linear-gradient(unquote($pos), $gradient);
 	background-image:     -moz-linear-gradient(unquote($pos), $gradient);
-	background-image:      -ms-linear-gradient(unquote($pos), $gradient);
 	background-image:       -o-linear-gradient(unquote($pos), $gradient);
 	background-image: unquote('linear-gradient(#{$pos_newsyntax}, #{$gradient})');
 }

--- a/partials/_linear-gradient.scss
+++ b/partials/_linear-gradient.scss
@@ -19,7 +19,6 @@
  *   background-image: -webkit-gradient(linear, <direction - old converted>, from(<from>), to(<to>));
  *   background-image: -webkit-linear-gradient(<direction - converted>, <from>, <to>);
  *   background-image:    -moz-linear-gradient(<direction - converted>, <from>, <to>);
- *   background-image:     -ms-linear-gradient(<direction - converted>, <from>, <to>);
  *   background-image:      -o-linear-gradient(<direction - converted>, <from>, <to>);
  *   background-image:         linear-gradient(<direction>, <from>, <to>);
  *
@@ -42,7 +41,6 @@
 	background-image: -webkit-gradient(linear, unquote(nth($directions, 2)), from($from), to($to)); // Android 2.1-3.0
 	background-image: -webkit-linear-gradient(unquote(nth($directions, 1)), $from, $to);
 	background-image:    -moz-linear-gradient(unquote(nth($directions, 1)), $from, $to);
-	background-image:     -ms-linear-gradient(unquote(nth($directions, 1)), $from, $to);
 	background-image:      -o-linear-gradient(unquote(nth($directions, 1)), $from, $to);
 	background-image:         linear-gradient(unquote($direction),     $from, $to);
 }

--- a/partials/_multiple-colored-gradient.scss
+++ b/partials/_multiple-colored-gradient.scss
@@ -12,7 +12,6 @@
  * @returns
  *   background-image: -webkit-linear-gradient(top, <stops[1]>, <stops[2]>, ..., <stops[n]>);
  *   background-image:    -moz-linear-gradient(top, <stops[1]>, <stops[2]>, ..., <stops[n]>);
- *   background-image:     -ms-linear-gradient(top, <stops[1]>, <stops[2]>, ..., <stops[n]>);
  *   background-image:      -o-linear-gradient(top, <stops[1]>, <stops[2]>, ..., <stops[n]>);
  *   background-image:         linear-gradient(to bottom, <stops[1]>, <stops[2]>, ..., <stops[n]>);
  *
@@ -68,7 +67,6 @@
 
 	background-image:  -webkit-linear-gradient(unquote($pos), $gradient);
 	background-image:     -moz-linear-gradient(unquote($pos), $gradient);
-	background-image:      -ms-linear-gradient(unquote($pos), $gradient);
 	background-image:       -o-linear-gradient(unquote($pos), $gradient);
 	background-image: unquote('linear-gradient(#{$pos_newsyntax}, #{$gradient})');
 }

--- a/tests/css/main.css
+++ b/tests/css/main.css
@@ -142,7 +142,6 @@
  *   background-image: -webkit-gradient(linear, <direction - old converted>, from(<from>), to(<to>));
  *   background-image: -webkit-linear-gradient(<direction - converted>, <from>, <to>);
  *   background-image:    -moz-linear-gradient(<direction - converted>, <from>, <to>);
- *   background-image:     -ms-linear-gradient(<direction - converted>, <from>, <to>);
  *   background-image:      -o-linear-gradient(<direction - converted>, <from>, <to>);
  *   background-image:         linear-gradient(<direction>, <from>, <to>);
  *
@@ -203,7 +202,6 @@
  * @returns
  *   background-image: -webkit-linear-gradient(top, <stops[1]>, <stops[2]>, ..., <stops[n]>);
  *   background-image:    -moz-linear-gradient(top, <stops[1]>, <stops[2]>, ..., <stops[n]>);
- *   background-image:     -ms-linear-gradient(top, <stops[1]>, <stops[2]>, ..., <stops[n]>);
  *   background-image:      -o-linear-gradient(top, <stops[1]>, <stops[2]>, ..., <stops[n]>);
  *   background-image:         linear-gradient(to bottom, <stops[1]>, <stops[2]>, ..., <stops[n]>);
  *
@@ -412,7 +410,6 @@ html {
   background-image: -webkit-gradient(linear, left top, left bottom, from(#dddddd), to(#bbbbbb));
   background-image: -webkit-linear-gradient(top, #dddddd, #bbbbbb);
   background-image: -moz-linear-gradient(top, #dddddd, #bbbbbb);
-  background-image: -ms-linear-gradient(top, #dddddd, #bbbbbb);
   background-image: -o-linear-gradient(top, #dddddd, #bbbbbb);
   background-image: linear-gradient(to bottom, #dddddd, #bbbbbb);
 }
@@ -422,7 +419,6 @@ html {
   background-image: -webkit-gradient(linear, top left, bottom right, from(#dddddd), to(#555555));
   background-image: -webkit-linear-gradient(left, #dddddd, #555555);
   background-image: -moz-linear-gradient(left, #dddddd, #555555);
-  background-image: -ms-linear-gradient(left, #dddddd, #555555);
   background-image: -o-linear-gradient(left, #dddddd, #555555);
   background-image: linear-gradient(to right, #dddddd, #555555);
 }
@@ -432,7 +428,6 @@ html {
   background-image: -webkit-gradient(linear, mod(405deg, 360deg), from(white), to(black));
   background-image: -webkit-linear-gradient(mod(405deg, 360deg), white, black);
   background-image: -moz-linear-gradient(mod(405deg, 360deg), white, black);
-  background-image: -ms-linear-gradient(mod(405deg, 360deg), white, black);
   background-image: -o-linear-gradient(mod(405deg, 360deg), white, black);
   background-image: linear-gradient(45deg, white, black);
   padding: 50px 0;
@@ -448,7 +443,6 @@ html {
   */
   background-image: -webkit-linear-gradient(top, #aaffff 0%, #ffaaff 20%, #ffffaa 40%, #aaaaff 60%, #ffaaaa 80%, #aaaaaa 100%);
   background-image: -moz-linear-gradient(top, #aaffff 0%, #ffaaff 20%, #ffffaa 40%, #aaaaff 60%, #ffaaaa 80%, #aaaaaa 100%);
-  background-image: -ms-linear-gradient(top, #aaffff 0%, #ffaaff 20%, #ffffaa 40%, #aaaaff 60%, #ffaaaa 80%, #aaaaaa 100%);
   background-image: -o-linear-gradient(top, #aaffff 0%, #ffaaff 20%, #ffffaa 40%, #aaaaff 60%, #ffaaaa 80%, #aaaaaa 100%);
   background-image: linear-gradient(to bottom, #aaffff 0%, #ffaaff 20%, #ffffaa 40%, #aaaaff 60%, #ffaaaa 80%, #aaaaaa 100%);
 }


### PR DESCRIPTION
There is no need to prefix -ms for gradients. IE 10, 11 support unprefixed gradients.

In accordance with:
http://caniuse.com/#search=linear-gradient
http://lea.verou.me/2013/04/can-we-get-rid-of-gradient-prefixes/
