### PR TITLE
Update _rem.scss

### DIFF
--- a/partials/_rem.scss
+++ b/partials/_rem.scss
@@ -41,11 +41,11 @@
 		// If the value is not zero, convert it from px to rem
 		} @else {
 			$px-values: append($px-values, ($value * $main-font-size) );
-			$rem-values: append($rem-values, #{$value}rem);
+			$rem-values: append($rem-values, #{$value});
 		}
 	}
 
 	// Return the property and its list of converted values
 	#{$property}: #{$px-values};
-	#{$property}: #{$rem-values};
+	#{$property}: #{$rem-values}rem;
 }


### PR DESCRIPTION
The rem value output generated an extra space between the value and rem. By moving 'rem' to the output itself, this issue was fixed.

I don't know if more people had this issue, but I got this output by using the previous version:

font-size: 40px;
font-size: 2.5 rem;

With my change it outputs correctly:

font-size: 40px;
font-size: 2.5rem;

Hope this helps more people...
