### PR TITLE
Remove -ms-filter for opacity mixin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ### HEAD
 
+* Remove -ms-filter for opacity mixin
+
 ### 0.7.0 - 19.12.2013
 * Add breakpoint mixin
 * Update animation description

--- a/mixins.scss
+++ b/mixins.scss
@@ -1,4 +1,4 @@
-/*! sass-mixins - v0.7.0 - 2013-12-19 *//**
+/*! sass-mixins - v0.7.0 - 2013-12-29 *//**
  * @description
  * Generates keyframe animations
  *
@@ -525,8 +525,7 @@
  * @param value
  * @returns
  *   opacity: <value>;
- *       filter: alpha(opacity=<value * 100>);
- *   -ms-filter: "progid:DXImageTransform.Microsoft.Alpha(Opacity=<value * 100>)";
+ *    filter: alpha(opacity=<value * 100>);
  *
  * @example
  *   .selector {
@@ -535,8 +534,7 @@
  */
 @mixin x-opacity ($value: 1) {
     opacity: $value;
-        filter: alpha(opacity=$value * 100);
-    -ms-filter: "progid:DXImageTransform.Microsoft.Alpha(Opacity=#{$value * 100})";
+     filter: alpha(opacity=$value * 100);
 }
 
 /**

--- a/partials/_opacity.scss
+++ b/partials/_opacity.scss
@@ -10,8 +10,7 @@
  * @param value
  * @returns
  *   opacity: <value>;
- *       filter: alpha(opacity=<value * 100>);
- *   -ms-filter: "progid:DXImageTransform.Microsoft.Alpha(Opacity=<value * 100>)";
+ *    filter: alpha(opacity=<value * 100>);
  *
  * @example
  *   .selector {
@@ -20,6 +19,5 @@
  */
 @mixin x-opacity ($value: 1) {
     opacity: $value;
-        filter: alpha(opacity=$value * 100);
-    -ms-filter: "progid:DXImageTransform.Microsoft.Alpha(Opacity=#{$value * 100})";
+     filter: alpha(opacity=$value * 100);
 }

--- a/tests/css/main.css
+++ b/tests/css/main.css
@@ -1,6 +1,6 @@
-/*! sass-mixins - v0.7.0 - 2013-12-19 */
+/*! sass-mixins - v0.7.0 - 2013-12-29 */
 @charset "UTF-8";
-/* sass-mixins - v0.7.0 - 2013-12-19 */
+/*! sass-mixins - v0.7.0 - 2013-12-29 */
                                        /**
 * @description
 * Generates keyframe animations
@@ -256,8 +256,7 @@
  * @param value
  * @returns
  *   opacity: <value>;
- *       filter: alpha(opacity=<value * 100>);
- *   -ms-filter: "progid:DXImageTransform.Microsoft.Alpha(Opacity=<value * 100>)";
+ *    filter: alpha(opacity=<value * 100>);
  *
  * @example
  *   .selector {
@@ -557,7 +556,6 @@ html {
 .opacity {
   opacity: 0.4;
   filter: alpha(opacity=40);
-  -ms-filter: "progid:DXImageTransform.Microsoft.Alpha(Opacity=40)";
 }
 
 .rem {


### PR DESCRIPTION
IE8 -ms-filter is synonymous for filter. So, we can remove it.
