### PR TITLE
Updating FF support (now 2 - 28)

### DIFF
--- a/partials/_box-sizing.scss
+++ b/partials/_box-sizing.scss
@@ -20,6 +20,6 @@
  */
 @mixin x-box-sizing ($type: border-box) {
 	-webkit-box-sizing: $type; // Safari <= 5.0, Chrome <= 9.0, iOS Safari 3.2 - 4.3 and Android 2.1 - 3.0
-	   -moz-box-sizing: $type; // FF 2.0+
+	   -moz-box-sizing: $type; // FF 2.0 - 28.0
 	        box-sizing: $type; // IE 8, Opera 9.5+
 }


### PR DESCRIPTION
As of version 29, Firefox support the unprefixed `box-sizing` property.
