### PR TITLE
Adjust x-opacity mixin to prevent libsass from throwing an "invalid oper...

### DIFF
--- a/mixins.scss
+++ b/mixins.scss
@@ -769,8 +769,10 @@
  *   }
  */
 @mixin x-opacity ($value: 1) {
+	$value-percentage : $value * 100;
+
 	opacity: $value;
-	filter: alpha(opacity=$value * 100);
+	filter: alpha(opacity=$value-percentage);
 }
 
 /**


### PR DESCRIPTION
...ands for multiplication" error
